### PR TITLE
fix: require node 14.18.0

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -10,7 +10,7 @@ const project = new cdk.JsiiProject({
   defaultReleaseBranch: 'main',
   name: 'construct-hub-probe',
   releaseToNpm: true,
-  minNodeVersion: '14.17.0',
+  minNodeVersion: '14.18.0',
   repositoryUrl: 'https://github.com/cdklabs/construct-hub-probe.git',
   peerDeps: [
     'constructs',


### PR DESCRIPTION
aws/constructs#1611 changes the min version requirement for constructs to be 14.18.0

Fixes failing workflows.