### PR TITLE
fix: auto commits are not triggering a release

### DIFF
--- a/.github/workflows/auto-commit.yml
+++ b/.github/workflows/auto-commit.yml
@@ -20,5 +20,5 @@ jobs:
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           branch: github-actions/auto-commit
-          title: "chore: auto commit to trigger new release"
+          title: "feat: auto commit to trigger new release"
           labels: auto-approve

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -59,7 +59,7 @@ bump.addJobs({
         with: {
           token: '${{ secrets.PROJEN_GITHUB_TOKEN }}',
           branch: 'github-actions/auto-commit',
-          title: 'chore: auto commit to trigger new release',
+          title: 'feat: auto commit to trigger new release',
           labels: 'auto-approve',
         },
       },


### PR DESCRIPTION
Ever since https://github.com/cdklabs/cdklabs-projen-project-types/pull/172, we stopped releasing the probe.